### PR TITLE
Add the jet selection for ParT AK4

### DIFF
--- a/DataFormats/BTauReco/interface/ParticleTransformerAK4Features.h
+++ b/DataFormats/BTauReco/interface/ParticleTransformerAK4Features.h
@@ -11,6 +11,7 @@ namespace btagbtvdeep {
 
   class ParticleTransformerAK4Features {
   public:
+    bool is_filled = true;
     std::vector<SecondaryVertexFeatures> sv_features;
 
     std::vector<NeutralCandidateFeatures> n_pf_features;

--- a/RecoBTag/FeatureTools/plugins/ParticleTransformerAK4TagInfoProducer.cc
+++ b/RecoBTag/FeatureTools/plugins/ParticleTransformerAK4TagInfoProducer.cc
@@ -197,219 +197,229 @@ void ParticleTransformerAK4TagInfoProducer::produce(edm::Event& iEvent, const ed
     // reco jet reference (use as much as possible)
     const auto& jet = jets->at(jet_n);
     if (jet.pt() < 15.0) {
-      continue;
+      features.is_filled = false;
+    }
+    if (std::abs(jet.eta()) > 2.5) {
+      features.is_filled = false;
     }
     // dynamical casting to pointers, null if not possible
     const auto* pf_jet = dynamic_cast<const reco::PFJet*>(&jet);
     const auto* pat_jet = dynamic_cast<const pat::Jet*>(&jet);
     edm::RefToBase<reco::Jet> jet_ref(jets, jet_n);
 
-    math::XYZVector jet_dir = jet.momentum().Unit();
-    GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
+    if (features.is_filled) {
+      math::XYZVector jet_dir = jet.momentum().Unit();
+      GlobalVector jet_ref_track_dir(jet.px(), jet.py(), jet.pz());
 
-    // copy which will be sorted
-    auto svs_sorted = *svs;
-    // sort by dxy
-    std::sort(svs_sorted.begin(), svs_sorted.end(), [&pv](const auto& sva, const auto& svb) {
-      return btagbtvdeep::sv_vertex_comparator(sva, svb, pv);
-    });
-    // fill features from secondary vertices
-    for (const auto& sv : svs_sorted) {
-      if (reco::deltaR2(sv, jet_dir) > (jet_radius_ * jet_radius_))
-        continue;
-      else {
-        features.sv_features.emplace_back();
-        // in C++17 could just get from emplace_back output
-        auto& sv_features = features.sv_features.back();
-        btagbtvdeep::svToFeatures(sv, pv, jet, sv_features, flip_);
-      }
-    }
-
-    // stuff required for dealing with pf candidates
-
-    std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted, n_sorted;
-
-    // to cache the TrackInfo
-    std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
-
-    // unsorted reference to sv
-    const auto& svs_unsorted = *svs;
-    // fill collection, from DeepTNtuples plus some styling
-    for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
-      auto cand = jet.daughter(i);
-      if (cand) {
-        // candidates under 950MeV (configurable) are not considered
-        // might change if we use also white-listing
-        if (cand->pt() < min_candidate_pt_)
+      // copy which will be sorted
+      auto svs_sorted = *svs;
+      // sort by dxy
+      std::sort(svs_sorted.begin(), svs_sorted.end(), [&pv](const auto& sva, const auto& svb) {
+        return btagbtvdeep::sv_vertex_comparator(sva, svb, pv);
+      });
+      // fill features from secondary vertices
+      for (const auto& sv : svs_sorted) {
+        if (reco::deltaR2(sv, jet_dir) > (jet_radius_ * jet_radius_))
           continue;
-        if (cand->charge() != 0) {
-          auto& trackinfo = trackinfos.emplace(i, track_builder).first->second;
-          trackinfo.buildTrackInfo(cand, jet_dir, jet_ref_track_dir, pv);
-
-          c_sorted.emplace_back(
-              i, trackinfo.getTrackSip2dSig(), -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand), cand->pt() / jet.pt());
-        } else {
-          n_sorted.emplace_back(i, -1, -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand), cand->pt() / jet.pt());
+        else {
+          features.sv_features.emplace_back();
+          // in C++17 could just get from emplace_back output
+          auto& sv_features = features.sv_features.back();
+          btagbtvdeep::svToFeatures(sv, pv, jet, sv_features, flip_);
         }
       }
-    }
 
-    // sort collections (open the black-box if you please)
-    std::sort(c_sorted.begin(), c_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
-    std::sort(n_sorted.begin(), n_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+      // stuff required for dealing with pf candidates
 
-    std::vector<size_t> c_sortedindices, n_sortedindices;
+      std::vector<btagbtvdeep::SortingClass<size_t>> c_sorted, n_sorted;
 
-    // this puts 0 everywhere and the right position in ind
-    c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
-    n_sortedindices = btagbtvdeep::invertSortingVector(n_sorted);
+      // to cache the TrackInfo
+      std::map<unsigned int, btagbtvdeep::TrackInfoBuilder> trackinfos;
 
-    // set right size to vectors
-    features.c_pf_features.clear();
-    features.c_pf_features.resize(c_sorted.size());
-    features.n_pf_features.clear();
-    features.n_pf_features.resize(n_sorted.size());
+      // unsorted reference to sv
+      const auto& svs_unsorted = *svs;
+      // fill collection, from DeepTNtuples plus some styling
+      for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
+        auto cand = jet.daughter(i);
+        if (cand) {
+          // candidates under 950MeV (configurable) are not considered
+          // might change if we use also white-listing
+          if (cand->pt() < min_candidate_pt_)
+            continue;
+          if (cand->charge() != 0) {
+            auto& trackinfo = trackinfos.emplace(i, track_builder).first->second;
+            trackinfo.buildTrackInfo(cand, jet_dir, jet_ref_track_dir, pv);
 
-    for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
-      // get pointer and check that is correct
-      auto cand = dynamic_cast<const reco::Candidate*>(jet.daughter(i));
-      if (!cand)
-        continue;
-      // candidates under 950MeV are not considered
-      // might change if we use also white-listing
-      if (cand->pt() < 0.95)
-        continue;
-
-      auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
-      auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
-
-      // need some edm::Ptr or edm::Ref if reco candidates
-      reco::PFCandidatePtr reco_ptr;
-      if (pf_jet) {
-        reco_ptr = pf_jet->getPFConstituent(i);
-      } else if (pat_jet && reco_cand) {
-        reco_ptr = pat_jet->getPFConstituent(i);
-      }
-
-      reco::CandidatePtr cand_ptr;
-      if (pat_jet) {
-        cand_ptr = pat_jet->sourceCandidatePtr(i);
-      }
-
-      //
-      // Access puppi weight from ValueMap.
-      //
-      float puppiw = 1.0;  // Set to fallback value
-
-      if (reco_cand) {
-        if (use_puppi_value_map_)
-          puppiw = (*puppi_value_map)[reco_ptr];
-        else if (!fallback_puppi_weight_) {
-          throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
-              << "use fallback_puppi_weight option to use " << puppiw << " for reco_cand as default";
-        }
-      } else if (packed_cand) {
-        if (use_puppi_value_map_)
-          puppiw = (*puppi_value_map)[cand_ptr];
-        else if (!fallback_puppi_weight_) {
-          throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
-              << "use fallback_puppi_weight option to use " << puppiw << " for packed_cand as default";
-        }
-      } else {
-        throw edm::Exception(edm::errors::InvalidReference)
-            << "Cannot convert to either reco::PFCandidate or pat::PackedCandidate";
-      }
-
-      float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand);
-      float distminpfcandsv = 0;
-      if (cand->charge() != 0) {
-        // is charged candidate
-        auto entry = c_sortedindices.at(i);
-
-        // get cached track info
-        auto& trackinfo = trackinfos.at(i);
-
-        // get_ref to vector element
-        auto& c_pf_features = features.c_pf_features.at(entry);
-        // fill feature structure
-        if (packed_cand) {
-          if (packed_cand->hasTrackDetails()) {
-            const reco::Track& PseudoTrack = packed_cand->pseudoTrack();
-            reco::TransientTrack transientTrack;
-            transientTrack = track_builder->build(PseudoTrack);
-            distminpfcandsv = btagbtvdeep::mindistsvpfcand(svs_unsorted, transientTrack);
+            c_sorted.emplace_back(i,
+                                  trackinfo.getTrackSip2dSig(),
+                                  -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand),
+                                  cand->pt() / jet.pt());
+          } else {
+            n_sorted.emplace_back(i, -1, -btagbtvdeep::mindrsvpfcand(svs_unsorted, cand), cand->pt() / jet.pt());
           }
+        }
+      }
 
-          btagbtvdeep::packedCandidateToFeatures(packed_cand,
+      // sort collections (open the black-box if you please)
+      std::sort(c_sorted.begin(), c_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+      std::sort(n_sorted.begin(), n_sorted.end(), btagbtvdeep::SortingClass<std::size_t>::compareByABCInv);
+
+      std::vector<size_t> c_sortedindices, n_sortedindices;
+
+      // this puts 0 everywhere and the right position in ind
+      c_sortedindices = btagbtvdeep::invertSortingVector(c_sorted);
+      n_sortedindices = btagbtvdeep::invertSortingVector(n_sorted);
+
+      // set right size to vectors
+      features.c_pf_features.clear();
+      features.c_pf_features.resize(c_sorted.size());
+      features.n_pf_features.clear();
+      features.n_pf_features.resize(n_sorted.size());
+
+      for (unsigned int i = 0; i < jet.numberOfDaughters(); i++) {
+        // get pointer and check that is correct
+        auto cand = dynamic_cast<const reco::Candidate*>(jet.daughter(i));
+        if (!cand)
+          continue;
+        // candidates under 950MeV are not considered
+        // might change if we use also white-listing
+        if (cand->pt() < 0.95)
+          continue;
+
+        auto packed_cand = dynamic_cast<const pat::PackedCandidate*>(cand);
+        auto reco_cand = dynamic_cast<const reco::PFCandidate*>(cand);
+
+        // need some edm::Ptr or edm::Ref if reco candidates
+        reco::PFCandidatePtr reco_ptr;
+        if (pf_jet) {
+          reco_ptr = pf_jet->getPFConstituent(i);
+        } else if (pat_jet && reco_cand) {
+          reco_ptr = pat_jet->getPFConstituent(i);
+        }
+
+        reco::CandidatePtr cand_ptr;
+        if (pat_jet) {
+          cand_ptr = pat_jet->sourceCandidatePtr(i);
+        }
+
+        //
+        // Access puppi weight from ValueMap.
+        //
+        float puppiw = 1.0;  // Set to fallback value
+
+        if (reco_cand) {
+          if (use_puppi_value_map_)
+            puppiw = (*puppi_value_map)[reco_ptr];
+          else if (!fallback_puppi_weight_) {
+            throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
+                << "use fallback_puppi_weight option to use " << puppiw << " for reco_cand as default";
+          }
+        } else if (packed_cand) {
+          if (use_puppi_value_map_)
+            puppiw = (*puppi_value_map)[cand_ptr];
+          else if (!fallback_puppi_weight_) {
+            throw edm::Exception(edm::errors::InvalidReference, "PUPPI value map missing")
+                << "use fallback_puppi_weight option to use " << puppiw << " for packed_cand as default";
+          }
+        } else {
+          throw edm::Exception(edm::errors::InvalidReference)
+              << "Cannot convert to either reco::PFCandidate or pat::PackedCandidate";
+        }
+
+        float drminpfcandsv = btagbtvdeep::mindrsvpfcand(svs_unsorted, cand);
+        float distminpfcandsv = 0;
+        if (cand->charge() != 0) {
+          // is charged candidate
+          auto entry = c_sortedindices.at(i);
+
+          // get cached track info
+          auto& trackinfo = trackinfos.at(i);
+
+          // get_ref to vector element
+          auto& c_pf_features = features.c_pf_features.at(entry);
+          // fill feature structure
+          if (packed_cand) {
+            if (packed_cand->hasTrackDetails()) {
+              const reco::Track& PseudoTrack = packed_cand->pseudoTrack();
+              reco::TransientTrack transientTrack;
+              transientTrack = track_builder->build(PseudoTrack);
+              distminpfcandsv = btagbtvdeep::mindistsvpfcand(svs_unsorted, transientTrack);
+            }
+
+            btagbtvdeep::packedCandidateToFeatures(packed_cand,
+                                                   jet,
+                                                   trackinfo,
+                                                   is_weighted_jet_,
+                                                   drminpfcandsv,
+                                                   static_cast<float>(jet_radius_),
+                                                   puppiw,
+                                                   c_pf_features,
+                                                   flip_,
+                                                   distminpfcandsv);
+          } else if (reco_cand) {
+            // get vertex association quality
+            int pv_ass_quality = 0;  // fallback value
+            if (use_pvasq_value_map_) {
+              pv_ass_quality = (*pvasq_value_map)[reco_ptr];
+            } else if (!fallback_vertex_association_) {
+              throw edm::Exception(edm::errors::InvalidReference, "vertex association missing")
+                  << "use fallback_vertex_association option to use" << pv_ass_quality
+                  << "as default quality and closest dz PV as criteria";
+            }
+            // getting the PV as PackedCandidatesProducer
+            // but using not the slimmed but original vertices
+            auto ctrack = reco_cand->bestTrack();
+            int pvi = -1;
+            float dist = 1e99;
+            for (size_t ii = 0; ii < vtxs->size(); ii++) {
+              float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
+              if (dz < dist) {
+                pvi = ii;
+                dist = dz;
+              }
+            }
+            auto PV = reco::VertexRef(vtxs, pvi);
+            if (use_pvasq_value_map_) {
+              const reco::VertexRef& PV_orig = (*pvas)[reco_ptr];
+              if (PV_orig.isNonnull())
+                PV = reco::VertexRef(vtxs, PV_orig.key());
+            }
+            btagbtvdeep::recoCandidateToFeatures(reco_cand,
                                                  jet,
                                                  trackinfo,
                                                  is_weighted_jet_,
                                                  drminpfcandsv,
                                                  static_cast<float>(jet_radius_),
                                                  puppiw,
+                                                 pv_ass_quality,
+                                                 PV,
                                                  c_pf_features,
                                                  flip_,
                                                  distminpfcandsv);
-        } else if (reco_cand) {
-          // get vertex association quality
-          int pv_ass_quality = 0;  // fallback value
-          if (use_pvasq_value_map_) {
-            pv_ass_quality = (*pvasq_value_map)[reco_ptr];
-          } else if (!fallback_vertex_association_) {
-            throw edm::Exception(edm::errors::InvalidReference, "vertex association missing")
-                << "use fallback_vertex_association option to use" << pv_ass_quality
-                << "as default quality and closest dz PV as criteria";
           }
-          // getting the PV as PackedCandidatesProducer
-          // but using not the slimmed but original vertices
-          auto ctrack = reco_cand->bestTrack();
-          int pvi = -1;
-          float dist = 1e99;
-          for (size_t ii = 0; ii < vtxs->size(); ii++) {
-            float dz = (ctrack) ? std::abs(ctrack->dz(((*vtxs)[ii]).position())) : 0;
-            if (dz < dist) {
-              pvi = ii;
-              dist = dz;
-            }
+        } else {
+          // is neutral candidate
+          auto entry = n_sortedindices.at(i);
+          // get_ref to vector element
+          auto& n_pf_features = features.n_pf_features.at(entry);
+          // fill feature structure
+          if (packed_cand) {
+            btagbtvdeep::packedCandidateToFeatures(packed_cand,
+                                                   jet,
+                                                   is_weighted_jet_,
+                                                   drminpfcandsv,
+                                                   static_cast<float>(jet_radius_),
+                                                   puppiw,
+                                                   n_pf_features);
+          } else if (reco_cand) {
+            btagbtvdeep::recoCandidateToFeatures(
+                reco_cand, jet, is_weighted_jet_, drminpfcandsv, static_cast<float>(jet_radius_), puppiw, n_pf_features);
           }
-          auto PV = reco::VertexRef(vtxs, pvi);
-          if (use_pvasq_value_map_) {
-            const reco::VertexRef& PV_orig = (*pvas)[reco_ptr];
-            if (PV_orig.isNonnull())
-              PV = reco::VertexRef(vtxs, PV_orig.key());
-          }
-          btagbtvdeep::recoCandidateToFeatures(reco_cand,
-                                               jet,
-                                               trackinfo,
-                                               is_weighted_jet_,
-                                               drminpfcandsv,
-                                               static_cast<float>(jet_radius_),
-                                               puppiw,
-                                               pv_ass_quality,
-                                               PV,
-                                               c_pf_features,
-                                               flip_,
-                                               distminpfcandsv);
-        }
-      } else {
-        // is neutral candidate
-        auto entry = n_sortedindices.at(i);
-        // get_ref to vector element
-        auto& n_pf_features = features.n_pf_features.at(entry);
-        // fill feature structure
-        if (packed_cand) {
-          btagbtvdeep::packedCandidateToFeatures(
-              packed_cand, jet, is_weighted_jet_, drminpfcandsv, static_cast<float>(jet_radius_), puppiw, n_pf_features);
-        } else if (reco_cand) {
-          btagbtvdeep::recoCandidateToFeatures(
-              reco_cand, jet, is_weighted_jet_, drminpfcandsv, static_cast<float>(jet_radius_), puppiw, n_pf_features);
         }
       }
     }
-
     output_tag_infos->emplace_back(features, jet_ref);
   }
-
   iEvent.put(std::move(output_tag_infos));
 }
 


### PR DESCRIPTION
This PR include the jet selection correction for ParT AK4. We add a bool selection to the ParT features allowing us to flag which jets match our criteria and following this we built the inputs and predict for the good jets. Non selected jets receive a default prob of -1 for all the nodes